### PR TITLE
Fix a bug where using groups and counts with long table names return incorrect results

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -4,6 +4,47 @@ require "active_support/core_ext/enumerable"
 
 module ActiveRecord
   module Calculations
+    class ColumnAliasTracker # :nodoc:
+      def initialize(connection)
+        @connection = connection
+        @aliases = Hash.new(0)
+      end
+
+      def alias_for(field)
+        aliased_name = column_alias_for(field)
+
+        if @aliases[aliased_name] == 0
+          @aliases[aliased_name] = 1
+          aliased_name
+        else
+          # Update the count
+          count = @aliases[aliased_name] += 1
+          "#{truncate(aliased_name)}_#{count}"
+        end
+      end
+
+      private
+        # Converts the given field to the value that the database adapter returns as
+        # a usable column name:
+        #
+        #   column_alias_for("users.id")                 # => "users_id"
+        #   column_alias_for("sum(id)")                  # => "sum_id"
+        #   column_alias_for("count(distinct users.id)") # => "count_distinct_users_id"
+        #   column_alias_for("count(*)")                 # => "count_all"
+        def column_alias_for(field)
+          column_alias = +field
+          column_alias.gsub!(/\*/, "all")
+          column_alias.gsub!(/\W+/, " ")
+          column_alias.strip!
+          column_alias.gsub!(/ +/, "_")
+          @connection.table_alias_for(column_alias)
+        end
+
+        def truncate(name)
+          name.slice(0, @connection.table_alias_length - 2)
+        end
+    end
+
     # Count the records.
     #
     #   Person.count
@@ -386,14 +427,16 @@ module ActiveRecord
         end
         group_fields = arel_columns(group_fields)
 
+        column_alias_tracker = ColumnAliasTracker.new(connection)
+
         group_aliases = group_fields.map { |field|
           field = connection.visitor.compile(field) if Arel.arel_node?(field)
-          column_alias_for(field.to_s.downcase)
+          column_alias_tracker.alias_for(field.to_s.downcase)
         }
         group_columns = group_aliases.zip(group_fields)
 
         column = aggregate_column(column_name)
-        column_alias = column_alias_for("#{operation} #{column_name.to_s.downcase}")
+        column_alias = column_alias_tracker.alias_for("#{operation} #{column_name.to_s.downcase}")
         select_value = operation_over_aggregate_column(column, operation, distinct)
         select_value.as(connection.quote_column_name(column_alias))
 
@@ -447,23 +490,6 @@ module ActiveRecord
             result[key] = type_cast_calculated_value(row[column_alias], operation, type)
           end
         end
-      end
-
-      # Converts the given field to the value that the database adapter returns as
-      # a usable column name:
-      #
-      #   column_alias_for("users.id")                 # => "users_id"
-      #   column_alias_for("sum(id)")                  # => "sum_id"
-      #   column_alias_for("count(distinct users.id)") # => "count_distinct_users_id"
-      #   column_alias_for("count(*)")                 # => "count_all"
-      def column_alias_for(field)
-        column_alias = +field
-        column_alias.gsub!(/\*/, "all")
-        column_alias.gsub!(/\W+/, " ")
-        column_alias.strip!
-        column_alias.gsub!(/ +/, "_")
-
-        connection.table_alias_for(column_alias)
       end
 
       def type_for(field, &block)

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -21,6 +21,7 @@ require "models/developer"
 require "models/post"
 require "models/comment"
 require "models/rating"
+require "models/too_long_table_name"
 require "support/stubs/strong_parameters"
 require "support/async_helper"
 
@@ -450,6 +451,18 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_equal 50,  c[1]
     assert_equal 105, c[6]
     assert_equal 60,  c[2]
+  end
+
+  def test_should_group_by_multiple_fields_on_short_name_table
+    2.times do
+      TooLongTableName.create!(
+        too_long_long_long_long_long_long_cloumn_name_one_id: 1,
+        too_long_long_long_long_long_long_cloumn_name_two_id: 2
+      )
+    end
+
+    res = TooLongTableName.group(:to_long_long_long_long_long_long_cloumn_name_one_id, :to_long_long_long_long_long_long_cloumn_name_two_id).count
+    assert_equal({ [1, 2] => 2 }, res)
   end
 
   def test_should_calculate_with_invalid_field

--- a/activerecord/test/models/too_long_table_name.rb
+++ b/activerecord/test/models/too_long_table_name.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class TooLongTableName < ActiveRecord::Base
+  self.table_name = "too_long_long_long_long_long_long_long_long_table_name"
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -1317,6 +1317,11 @@ ActiveRecord::Schema.define do
     t.integer :id
     t.datetime :created_at
   end
+
+  create_table :too_long_long_long_long_long_long_long_long_table_name, force: true do |t|
+    t.integer :too_long_long_long_long_long_long_cloumn_name_one_id, null: false
+    t.integer :too_long_long_long_long_long_long_cloumn_name_two_id, null: false
+  end
 end
 
 Course.connection.create_table :courses, force: true do |t|


### PR DESCRIPTION
### Motivation / Background

When table names are very long, using group by and count together returns incorrect results.

Fixed [#1 ]

### Detail

Fixed a bug that the alias name of "group by" was too long and if it was cut by max identifier length, the first half of the name would be the same in both cases.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [ ] CI is passing.

